### PR TITLE
Updating requirements in documentation.

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -1,6 +1,8 @@
 # Download Current Release Version
 
-- **Java 8+ is required** for running the TestNG for Eclipse plugin.
+- **Java 11+ is required** for running the TestNG for Eclipse plugin v7.8.0 and above.
+
+- **Java 8 is required** for running the TestNG for Eclipse plugin Upto v7.4.0.
 
 - **Eclipse 4.2 and above is required**. Eclipse 3.x is NOT supported
   any more, please update your Eclipse to 4.2 or above.


### PR DESCRIPTION
Latest testng eclipse plugin requires java 11 from v7.8.0 and java 8 does not work. [Change log link](https://github.com/testng-team/testng-eclipse/blob/master/CHANGES.md#780)
Updating the requirements for the same in documentation.