### PR TITLE
fix #570: loosen the version range restriction of guava

### DIFF
--- a/testng-eclipse-plugin/META-INF/MANIFEST.MF
+++ b/testng-eclipse-plugin/META-INF/MANIFEST.MF
@@ -31,7 +31,7 @@ Require-Bundle: org.eclipse.ui,
  org.testng;bundle-version="[6.9.12,8.0.0)",
  org.eclipse.equinox.simpleconfigurator.manipulator;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.equinox.frameworkadmin;bundle-version="[2.0.0,3.0.0)",
- com.google.guava;bundle-version="[15.0.0,22.0.0)"
+ com.google.guava;bundle-version="[15.0.0,40.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,


### PR DESCRIPTION
fixes #570 by supporting guava 30+